### PR TITLE
More conservative interaction with the queue system

### DIFF
--- a/Gadi/nci-gadi.config
+++ b/Gadi/nci-gadi.config
@@ -13,9 +13,14 @@ profiles {
             autoMounts = true
         }
 
-        // Submit up to 1000 concurrent jobs (Gadi max)
+        // Submit up to 300 concurrent jobs (Gadi exec max)
+        // pollInterval and queueStatInterval of every 5 minutes
+        // submitRateLimit of 20 per minute
         executor {
-            queueSize = 1000
+            queueSize = 300
+            pollInterval = '5 min'
+            queueStatInterval = '5 min'
+            submitRateLimit = '20 min'
         }
 
         // Define process resource limits 
@@ -27,7 +32,7 @@ profiles {
             cache = 'lenient'
             stageInMode = 'symlink'
             queue = { task.memory < 128.GB ? 'normalbw' : (task.memory >= 128.GB && task.memory <= 190.GB ? 'normal' : (task.memory > 190.GB && task.memory <= 1020.GB ? 'hugemembw' : '')) }
-            beforeScript = 'module load singularity nextflow'
+            beforeScript = 'module load singularity'
         }
 
         // Write custom trace file with outputs required for SU calculation


### PR DESCRIPTION
General intent is to treat the queue system a bit more kindly, by 
1. limiting the total number of jobs to the exec queue limits; 
2. reducing the poll and qstat frequency;
3. slowing down the rate at which jobs are submitted to the queue. 

Removed nextflow itself from the beforeScript as there shouldn't be any need for it.